### PR TITLE
Mise à jour des valeurs des options de la liste déroulante pour utiliser des nombres entiers

### DIFF
--- a/desktop/php/pool.php
+++ b/desktop/php/pool.php
@@ -726,21 +726,21 @@ $eqLogics = eqLogic::byType($plugin->getId());
                         <div class="col-sm-2">
                             <select class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="lavageDuree" placeholder="" >
                                 <option value="0.5">0.5</option>
-                                <option value="1.0">1</option>
+                                <option value="1">1.0</option>
                                 <option value="1.5">1.5</option>
-                                <option value="2.0">2</option>
+                                <option value="2">2.0</option>
                                 <option value="2.5">2.5</option>
-                                <option value="3.0">3</option>
+                                <option value="3">3.0</option>
                                 <option value="3.5">3.5</option>
-                                <option value="4.0">4</option>
+                                <option value="4">4.0</option>
                                 <option value="4.5">4.5</option>
-                                <option value="5.0">5</option>
+                                <option value="5">5.0</option>
                                 <option value="5.5">5.5</option>
-                                <option value="6.0">6</option>
+                                <option value="6">6.0</option>
                                 <option value="6.5">6.5</option>
-                                <option value="7.0">7</option>
+                                <option value="7">7.0</option>
                                 <option value="7.5">7.5</option>
-                                <option value="8.0">8</option>
+                                <option value="8">8.0</option>
                             </select>
                         </div>
                     </div>
@@ -749,23 +749,23 @@ $eqLogics = eqLogic::byType($plugin->getId());
                         <label class="col-sm-2 control-label">{{Temps de rinçage du filtre à sable (min)}}</label>
                         <div class="col-sm-2">
                             <select class="eqLogicAttr form-control" data-l1key="configuration" data-l2key="rincageDuree" placeholder="" >
-                                <option value="0.0">0</option>
+                                <option value="0">0</option>
                                 <option value="0.5">0.5</option>
-                                <option value="1.0">1</option>
+                                <option value="1">1.0</option>
                                 <option value="1.5">1.5</option>
-                                <option value="2.0">2</option>
+                                <option value="2">2.0</option>
                                 <option value="2.5">2.5</option>
-                                <option value="3.0">3</option>
+                                <option value="3">3.0</option>
                                 <option value="3.5">3.5</option>
-                                <option value="4.0">4</option>
+                                <option value="4">4.0</option>
                                 <option value="4.5">4.5</option>
-                                <option value="5.0">5</option>
+                                <option value="5">5.0</option>
                                 <option value="5.5">5.5</option>
-                                <option value="6.0">6</option>
+                                <option value="6">6.0</option>
                                 <option value="6.5">6.5</option>
-                                <option value="7.0">7</option>
+                                <option value="7">7.0</option>
                                 <option value="7.5">7.5</option>
-                                <option value="8.0">8</option>
+                                <option value="8">8.0</option>
                             </select>
                         </div>
                     </div>


### PR DESCRIPTION
Les valeurs des options des menus déroulants « Temps de lavage du filtre à sable (min) » et « Temps de rinçage du filtre à sable (min) » ont été remplacées par des valeurs entières.